### PR TITLE
Alter ImageMagick policy to allow processing PDFs.

### DIFF
--- a/dockerfiles/manifold-api/Dockerfile
+++ b/dockerfiles/manifold-api/Dockerfile
@@ -7,6 +7,9 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get install -y nodejs
 RUN npm install -g mammoth@^1.4.16
 
+RUN sed -i '/<policy domain="coder" rights="none" pattern="PDF" \/>/d' \
+    /etc/ImageMagick-6/policy.xml
+
 COPY manifold-src/api /opt/manifold/api
 WORKDIR /opt/manifold/api
 ENV RAILS_LOG_TO_STDOUT=1


### PR DESCRIPTION
In response to some now-patched vulnerabilities in Ghostscript, Debian [changed](https://metadata.ftp-master.debian.org/changelogs//main/i/imagemagick/imagemagick_6.9.10.23+dfsg-2.1+deb10u1_changelog) the default configuration included with its ImageMatick packages to block access to PDFs. (The Manifold_api_sidekiq v5.1.3 image had ImageMagick packages from before this change.)