### PR TITLE
Update Bundler version.

### DIFF
--- a/dockerfiles/manifold-api/Dockerfile
+++ b/dockerfiles/manifold-api/Dockerfile
@@ -14,6 +14,6 @@ RUN sed -i '/<policy domain="coder" rights="none" pattern="PDF" \/>/d' \
 COPY manifold-src/api /opt/manifold/api
 WORKDIR /opt/manifold/api
 ENV RAILS_LOG_TO_STDOUT=1
-RUN gem install bundler:2.2.17
+RUN gem install bundler:2.2.19
 RUN bundle install
 COPY dockerfiles/manifold-api/scripts/start-and-run /opt/manifold/api/start-and-run


### PR DESCRIPTION
This should be equal to or greater than the version use to make Manifold's Gemfile.lock, which has been v2.2.19 since Manifold v7.